### PR TITLE
Make hosted items toggle when the item is selected in the item grids

### DIFF
--- a/scripts/autotracking/archipelago.lua
+++ b/scripts/autotracking/archipelago.lua
@@ -20,10 +20,6 @@ function resetItems()
 			if object then
 				object.Active = false
 			end
-      object = Tracker:FindObjectForCode(value[1].."_hosted")
-      if object then
-        object.Active = false
-      end
 		end
 	end
 end
@@ -105,7 +101,7 @@ function onItem(index, item_id, item_name, player_number)
     end
     return
   end
-	local object = Tracker:FindObjectForCode(value[1].."_hosted")
+	local object = Tracker:FindObjectForCode(value[1])
 	if object then
 		object.Active = true
     table.insert(OBTAINED_ITEMS, value[1])
@@ -168,9 +164,9 @@ function updateEvents(value)
       for _, code in pairs(event.codes) do
         if code.setting == nil or has(code.setting) then
           if code.code == "harbor_mail" then
-            Tracker:FindObjectForCode(code.code.."_hosted").Active = Tracker:FindObjectForCode(code.code.."_hosted").Active or value & bitmask ~= 0
+            Tracker:FindObjectForCode(code.code).Active = Tracker:FindObjectForCode(code.code).Active or value & bitmask ~= 0
           else
-            Tracker:FindObjectForCode(code.code.."_hosted").Active = value & bitmask ~= 0
+            Tracker:FindObjectForCode(code.code).Active = value & bitmask ~= 0
           end
         end
       end
@@ -187,7 +183,7 @@ function updateKeyItems(value)
       local bitmask = 2 ^ key_item.bit
       for _, code in pairs(key_item.codes) do
         if (code.setting == nil or has(code.setting)) and not tableContains(OBTAINED_ITEMS, code.code) then
-          Tracker:FindObjectForCode(code.code.."_hosted").Active = value & bitmask ~= 0
+          Tracker:FindObjectForCode(code.code).Active = value & bitmask ~= 0
         end
       end
     end

--- a/scripts/utils.lua
+++ b/scripts/utils.lua
@@ -37,6 +37,19 @@ function dump_table(o, depth)
 	end
 end
 
+function toggle_item(code)
+  local active = Tracker:FindObjectForCode(code).Active
+  code = code.."_hosted"
+  local object = Tracker:FindObjectForCode(code)
+  if object then
+    object.Active = active
+  else
+    if ENABLE_DEBUG_LOG then
+      print(string.format("toggle_item: could not find object for code %s", code))
+    end
+  end
+end
+
 function toggle_hosted_item(code)
   local active = Tracker:FindObjectForCode(code).Active
   code = code:gsub("_hosted", "")

--- a/scripts/watch.lua
+++ b/scripts/watch.lua
@@ -76,6 +76,7 @@ HOSTED_ITEMS =
 
 function initialize_watch_items()
   for _, code in pairs(HOSTED_ITEMS) do
+    ScriptHost:AddWatchForCode(code, code, toggle_item)
     ScriptHost:AddWatchForCode(code.."_hosted", code.."_hosted", toggle_hosted_item)
   end
 end


### PR DESCRIPTION
Items in the item grid would be toggled when the hosted item was clicked at the map locations but not the other way around. This should fix that.

This will cause both the toggle_item and toggle_hosted_item functions to both get called when an item is clicked but since the second one won't actually update the Active state of the item it won't result in an infinite loop.