### PR TITLE
Throttle autotracker updates to fix freezing and time-out issues

### DIFF
--- a/scripts/autotracking/archipelago.lua
+++ b/scripts/autotracking/archipelago.lua
@@ -195,7 +195,7 @@ function onItem(index, item_id, item_name, player_number)
 		if JSONITEM_RESET ~= -1 then
 			JSONITEM_TEMP_STATES[value[1]] = true
 		else
-			table.insert(JSONITEM_QUEUE, {object, true})
+			table.insert(JSONITEM_QUEUE, {value[1], true})
 			table.insert(OBTAINED_ITEMS, value[1])
 		end
 	elseif AUTOTRACKER_ENABLE_DEBUG_LOGGING_AP then
@@ -221,7 +221,7 @@ function onLocation(location_id, location_name)
         if JSONITEM_RESET ~= -1 then
           JSONITEM_TEMP_STATES_DEX[code] = true
         else
-          table.insert(JSONITEM_DEX_QUEUE, {object, true})
+          table.insert(JSONITEM_DEX_QUEUE, {code, true})
         end
       end
     elseif AUTOTRACKER_ENABLE_DEBUG_LOGGING_AP then


### PR DESCRIPTION
More details in commit descriptions and code comments.

Improved performance of autotracker "init" (like when you connect to the AP server and the tracker updates Location and Item states accordingly.) 
And in the same vein, fixed the issue of: if on a low-end PC, and playing Dexsanity (386 additional JsonItems to be updated), the autotracker "init" would freeze PopTracker for so long that it would get timed-out by the server.

I'd like to test it some more to make sure it's stable and working as expected.

Also, this appears to partially conflict with Pull Request #50, I can adjust this code to make integration a bit smoother if needed.